### PR TITLE
Add support for Mike Douglas' FDC+ 8MB disk images

### DIFF
--- a/disks/DISKDIR.TXT
+++ b/disks/DISKDIR.TXT
@@ -24,6 +24,7 @@ Available disks images:
 10100) DISK14.DSK: CP/M 3.0 disk 2 (utilities)
 10101) DISK15.DSK: Felix animation system for Dazzler
 10110) DISK16.DSK: CP/M 2.2 MITS+Tarbell
+10111) DISK17.DSK: CP/M 2.2 FDC+ 8MB
 ---------------------------------------------
 
 All images except 10,11,12,15 were put together by 

--- a/drive.cpp
+++ b/drive.cpp
@@ -54,6 +54,7 @@ void drive_set_realtime(bool b) {}
 #define DRIVE_NUM_SECTORS_MD    16
 #define DRIVE_NUM_TRACKS        77
 #define DRIVE_NUM_TRACKS_MD     35
+#define DRIVE_NUM_TRACKS_8MB  2048
 
 #define DRIVE_STATUS_HAVEDISK    1
 #define DRIVE_STATUS_HEADLOAD    2
@@ -64,12 +65,12 @@ void drive_set_realtime(bool b) {}
 static byte drive_selected = 0xff;
 static byte drive_mounted_disk[NUM_DRIVES];
 static byte drive_status[NUM_DRIVES];
-static byte drive_current_track[NUM_DRIVES];
+static uint16_t drive_current_track[NUM_DRIVES];
 static byte drive_current_sector[NUM_DRIVES];
 static byte drive_current_byte[NUM_DRIVES];
 static byte drive_sector_buffer[NUM_DRIVES][DRIVE_SECTOR_LENGTH];
 static byte drive_num_sectors[NUM_DRIVES];
-static byte drive_num_tracks[NUM_DRIVES];
+static uint16_t drive_num_tracks[NUM_DRIVES];
 static HOST_FILESYS_FILE_TYPE drive_file[NUM_DRIVES];
 
 #define DRIVE_SECTOR_TRUE_DELAY       5170
@@ -211,6 +212,12 @@ bool drive_mount(byte drive_num, byte image_num)
               // minidisk
               drive_num_tracks[drive_num] = DRIVE_NUM_TRACKS_MD;
               drive_num_sectors[drive_num] = DRIVE_NUM_SECTORS_MD;
+            }
+          else if ( size>8900000 )
+            {
+              // FDC+ 8MB disk
+              drive_num_tracks[drive_num] = DRIVE_NUM_TRACKS_8MB;
+              drive_num_sectors[drive_num] = DRIVE_NUM_SECTORS;
             }
           else
             {


### PR DESCRIPTION
This PR adds support for Mike Douglas' FDC+ 8MB disk images to the Altair disk controller:

The disk image “DISK17.DSK” is 56K CP/M 2.2 which supports 8Mb drives on drives A and B along with standard Altair floppy drives on drives C and D. The 8Mb drive looks like a standard Altair floppy drive but with 2048 tracks instead of 77 tracks.

CP/M is also patched to make the "user" construct of CP/M 2.2 more user-friendly (pun intended) to help organize the runaway file collection that tends to develop on a CP/M hard disk. The update provides the following specific features:

1. The current user number shows in the CP/M prompt (e.g., "A0>" or "A5>", or "B12>").
2. If a typed command is not found on the default user/drive combination, then drive A for the current user is searched, then drive A for user 0 is searched. By making drive A user 0 the repository for system files, most every command will run as expected even when in a different user/drive combination.